### PR TITLE
Parse Heredoc with `Cow<'a, str>` where possible

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 mod macros;
-
 mod errors;
 
 pub mod constants;
 pub mod iter;
+#[macro_use]
 pub mod utils;
 #[macro_use]
 pub mod parser;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,10 +2,10 @@
 mod macros;
 
 mod errors;
-mod utils;
 
 pub mod constants;
 pub mod iter;
+pub mod utils;
 #[macro_use]
 pub mod parser;
 pub mod value;

--- a/lib/src/parser.rs
+++ b/lib/src/parser.rs
@@ -14,6 +14,8 @@ pub mod object;
 pub mod string;
 pub mod tuple;
 
+use std::borrow::Cow;
+
 use crate::value::{self, MapValues, Value};
 use crate::{AsOwned, Error};
 use literals::Key;
@@ -73,7 +75,7 @@ named!(
         call!(null::null) => { |_| Value::Null }
         | call!(literals::number) => { |v| From::from(v) }
         | call!(boolean::boolean) => { |v| Value::Boolean(v) }
-        | string::string => { |v| Value::String(v) }
+        | string::string => { |v: Cow<str>| Value::String(v.to_string()) }
         | list => { |v| Value::List(v) }
         | map_expression => { |m| Value::Object(vec![m]) }
     )

--- a/lib/src/parser/attribute.rs
+++ b/lib/src/parser/attribute.rs
@@ -67,7 +67,7 @@ new
 line
 EOF
 "#,
-                ("test", Expression::String("new\nline".to_string())),
+                ("test", Expression::from("new\nline")),
                 "\n",
             ),
             (r#"test = [],"#, ("test", Expression::Tuple(vec![])), ","),

--- a/lib/src/parser/null.rs
+++ b/lib/src/parser/null.rs
@@ -9,8 +9,9 @@ named!(
     )
 );
 
+#[cfg(test)]
 #[test]
 fn parses_for_null() {
-    use crate::utils::test::ResultUtilsString;
+    use crate::utils::ResultUtilsString;
     null(CompleteStr("null")).unwrap_output();
 }

--- a/lib/src/parser/object.rs
+++ b/lib/src/parser/object.rs
@@ -216,7 +216,7 @@ new
 line
 EOF
 "#,
-                ("test", Expression::String("new\nline".to_string())),
+                ("test", Expression::from("new\nline")),
                 "\n",
             ),
             (r#"test = [],"#, ("test", Expression::Tuple(vec![])), ","),

--- a/lib/src/parser/string.rs
+++ b/lib/src/parser/string.rs
@@ -214,10 +214,8 @@ named!(
             call!(heredoc_end, &identifier) => {|_| ("", 0) }
             | do_parse!(
                 call!(nom::eol)
-                // TODO: Don't allocate a Vec of chars! Return the slice
                 >> content: take_till_match!(call!(heredoc_end, &identifier))
-                >> indentation: call!(heredoc_end, &identifier)
-                >> (content.0, indentation)
+                >> ((content.0).0, content.1)
             )
         )
         >> (unindent_heredoc(content.0, content.1))

--- a/lib/src/parser/string.rs
+++ b/lib/src/parser/string.rs
@@ -12,8 +12,8 @@ use log::debug;
 use nom::types::CompleteStr;
 use nom::ErrorKind;
 use nom::{
-    alt, call, complete, delimited, do_parse, escaped_transform, many_till, map, map_res, named,
-    opt, peek, preceded, return_error, tag, take_while1, take_while_m_n, IResult,
+    alt, call, complete, delimited, do_parse, escaped_transform, map, map_res, named, opt, peek,
+    preceded, return_error, tag, take_while1, take_while_m_n, IResult,
 };
 
 /// The StringLit production permits the escape sequences discussed for quoted template expressions
@@ -56,12 +56,10 @@ fn hex_to_string(s: &str) -> Result<String, InternalKind> {
         .to_string())
 }
 
-// TODO: Return Cow<'a, str>
 // Tab spaces are illegal and will cause bad output
-fn unindent_heredoc(charas: Vec<char>, indentation: usize) -> String {
-    let string: String = charas.into_iter().collect();
+fn unindent_heredoc(string: &str, indentation: usize) -> Cow<str> {
     if indentation == 0 {
-        return string;
+        return Cow::Borrowed(string);
     }
 
     let mut result = String::with_capacity(string.len());
@@ -81,7 +79,7 @@ fn unindent_heredoc(charas: Vec<char>, indentation: usize) -> String {
     }
     // Remove the last `\n`
     result.truncate(result.len() - 1);
-    result
+    Cow::Owned(result)
 }
 
 // Unescape characters according to the reference https://en.cppreference.com/w/cpp/language/escape
@@ -209,16 +207,17 @@ pub fn heredoc_end<'a>(
 
 // Parse a Heredoc string
 named!(
-    pub heredoc_string(CompleteStr) -> String,
+    pub heredoc_string(CompleteStr) -> Cow<str>,
     do_parse!(
         identifier: call!(heredoc_begin)
         >> content: alt!(
-            call!(heredoc_end, &identifier) => {|_| (vec![], 0) }
+            call!(heredoc_end, &identifier) => {|_| ("", 0) }
             | do_parse!(
                 call!(nom::eol)
                 // TODO: Don't allocate a Vec of chars! Return the slice
-                >> content: many_till!(call!(nom::anychar), call!(heredoc_end, &identifier))
-                >> (content)
+                >> content: take_till_match!(call!(heredoc_end, &identifier))
+                >> indentation: call!(heredoc_end, &identifier)
+                >> (content.0, indentation)
             )
         )
         >> (unindent_heredoc(content.0, content.1))
@@ -226,9 +225,9 @@ named!(
 );
 
 named!(
-    pub string(CompleteStr) -> String,
+    pub string(CompleteStr) -> Cow<str>,
     alt!(
-        quoted_string
+        quoted_string => { |s| Cow::Owned(s) }
         | heredoc_string
     )
 );
@@ -419,21 +418,21 @@ EOF
             ),
             (
                 r#"<<EOF
-something
+something 老虎
 EOF
 "#,
-                "something",
+                "something 老虎",
             ),
             (
                 r#"<<EOH
 something
-with
+with 老虎
 new lines
 and quotes "
                     EOH
 "#,
                 r#"something
-with
+with 老虎
 new lines
 and quotes ""#,
             ),
@@ -442,52 +441,52 @@ and quotes ""#,
     strip
     the
     spaces
-    but    not   these
+    but    not   these 老虎
     EOF
 "#,
                 r#"strip
 the
 spaces
-but    not   these"#,
+but    not   these 老虎"#,
             ),
             (
                 r#"<<-EOF
     strip
     the
     spaces
-    but    not   these
+    but    not   these 老虎
   EOF
 "#,
                 r#"  strip
   the
   spaces
-  but    not   these"#,
+  but    not   these 老虎"#,
             ),
             (
                 r#"<<-EOF
 strip
     the
 spaces
-    but    not   these
+    but    not   these 老虎
   EOF
 "#,
                 r#"strip
   the
 spaces
-  but    not   these"#,
+  but    not   these 老虎"#,
             ),
             (
                 r#"<<-EOF
   strip
     the
   spaces
-    but    not   these
+    but    not   these 老虎
     EOF
 "#,
                 r#"strip
 the
 spaces
-but    not   these"#,
+but    not   these 老虎"#,
             ),
         ];
 

--- a/lib/src/serde/de.rs
+++ b/lib/src/serde/de.rs
@@ -200,7 +200,7 @@ impl<'de> Deserializer<'de> {
     fn parse_string(&mut self) -> Result<String, Error> {
         let (remaining, output) = string(self.input)?;
         self.input = remaining;
-        Ok(output)
+        Ok(output.to_string())
     }
 
     fn parse_bytes(&mut self) -> Result<Vec<u8>, Error> {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,3 +1,4 @@
+use nom::types::{CompleteByteSlice, CompleteStr, Input};
 use std::ops::{Bound, RangeBounds};
 
 /// Recognizes at least 1 character while a predicate holds true
@@ -22,7 +23,8 @@ where
     /// Indicate if an `index` is the start and/or end of some boundary
     ///
     /// For example, in an implementation for a `&str`, this might be start
-    /// and/or end of a UTF-8 code point sequence (see [`str::is_char_boundary`]).
+    /// and/or end of a UTF-8 code point sequence
+    /// (see [`str::is_char_boundary`](https://doc.rust-lang.org/std/primitive.str.html#method.is_char_boundary)).
     fn is_slice_boundary(&self, index: usize) -> bool;
 
     /// Safe slicing. The start and the end of the range (if bounded) must be
@@ -47,6 +49,60 @@ where
         }
 
         Some(self.slice(range))
+    }
+}
+
+impl<'a, R> SliceBoundary<R> for &'a str
+where
+    R: RangeBounds<usize>,
+    &'a str: nom::Slice<R>,
+{
+    fn is_slice_boundary(&self, index: usize) -> bool {
+        self.is_char_boundary(index)
+    }
+}
+
+impl<'a, R> SliceBoundary<R> for CompleteStr<'a>
+where
+    R: RangeBounds<usize>,
+    CompleteStr<'a>: nom::Slice<R>,
+{
+    fn is_slice_boundary(&self, index: usize) -> bool {
+        self.is_char_boundary(index)
+    }
+}
+
+impl<'a, R, T> SliceBoundary<R> for &'a [T]
+where
+    R: RangeBounds<usize>,
+    &'a [T]: nom::Slice<R>,
+{
+    fn is_slice_boundary(&self, _index: usize) -> bool {
+        // Always true for arbitrary slices
+        true
+    }
+}
+
+impl<R, T> SliceBoundary<R> for Input<T>
+where
+    R: RangeBounds<usize>,
+    Input<T>: nom::Slice<R>,
+    T: nom::Slice<R>,
+{
+    fn is_slice_boundary(&self, _index: usize) -> bool {
+        // Always true for arbitrary slices
+        true
+    }
+}
+
+impl<'a, R> SliceBoundary<R> for CompleteByteSlice<'a>
+where
+    R: RangeBounds<usize>,
+    CompleteByteSlice<'a>: nom::Slice<R>,
+{
+    fn is_slice_boundary(&self, _index: usize) -> bool {
+        // Always true for arbitrary bytes
+        true
     }
 }
 

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -33,8 +33,9 @@ where
     /// If they are unsafe, then the implementation will return `None`.
     fn safe_slice(&self, range: R) -> Option<Self> {
         if !match range.start_bound() {
-            Bound::Included(start) => self.is_slice_boundary(start - 1),
-            Bound::Excluded(start) => self.is_slice_boundary(*start),
+            Bound::Included(start) => self.is_slice_boundary(*start),
+            // No such Range exist
+            Bound::Excluded(start) => self.is_slice_boundary(start + 1),
             Bound::Unbounded => true,
         } {
             return None;
@@ -199,3 +200,23 @@ mod test_utils {
 
 #[cfg(test)]
 pub(crate) use test_utils::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strings_are_sliced_safely() {
+        let s = "Löwe 老虎 Léopard";
+        assert_eq!(Some(s), s.safe_slice(..));
+        assert_eq!(Some("Löwe "), s.safe_slice(0..6));
+        assert_eq!(Some("Löwe "), s.safe_slice(..6));
+        assert_eq!(Some("老"), s.safe_slice(6..9));
+        assert_eq!(Some("老虎 Léopard"), s.safe_slice(6..));
+
+        // "老" is bytes 6 to 8
+        assert_eq!(None, s.safe_slice(6..8));
+        assert_eq!(None, s.safe_slice(7..));
+        assert_eq!(None, s.safe_slice(..7));
+    }
+}


### PR DESCRIPTION
Avoids needless allocation/copy when the string is used as-is.